### PR TITLE
Adding data-driven tries table

### DIFF
--- a/dashboard/pipeline2.html
+++ b/dashboard/pipeline2.html
@@ -5,6 +5,7 @@
     <title>WebKit Bot Watcher's Dashboard: Pipeline Metrics</title>
     <style type="text/css">
 
+
         /**
          * General page rules
          */
@@ -26,6 +27,7 @@
             margin-bottom: 32px;
             text-align: center;
         }
+
 
         /**
          * Queue flow diagrams
@@ -64,9 +66,13 @@
             text-align: center;
         }
 
+
         /**
          * Time histograms
          */
+
+        /* todo */
+
 
         /**
          * Tries table
@@ -81,16 +87,41 @@
         }
         .tries-table td,
         .tries-table th {
-            padding: 5px;
+            padding: 6px;
             text-align: left;
         }
+        .tries-table td:first-of-type,
+        .tries-table th:first-of-type {
+            padding-left: 24px;
+        }
+        .tries-table td:last-of-type,
+        .tries-table th:last-of-type {
+            padding-left: 24px;
+        }
         .tries-table thead {
-            padding-bottom: 4px;
-            margin-bottom: 4px;
             border-bottom: 3px solid #9C9C9C;
         }
-        .tries-table tbody {
-            padding-top: 10px;
+        .tries-table thead th {
+            padding-bottom: 10px;
+        }
+        .tries-table tbody tr:first-of-type td {
+            padding-top: 12px;
+        }
+        .tries-table tbody tr td:nth-of-type(1),
+        .tries-table tbody tr td:nth-of-type(2) {
+            text-align: center;
+        }
+
+        .tries-table .try-num {
+            display: block;
+            width: 18px;
+            height: 18px;
+            margin: auto;
+            border-radius: 100px;
+            border: 1px solid #A2A2A2;
+            background: white;
+            font-size: 12px;
+            line-height: 18px;
         }
 
     </style>
@@ -175,46 +206,58 @@
                 </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td>1</td>
-                    <td>&rarr;</td>
-                    <td><a href="#">2839492</a></td>
-                    <td>1h 30s ago</td>
-                    <td>30m 10s</td>
-                    <td><a href="#">agomez</a></td>
-                    <td><a href="#">141173: [GTK] Web Inspector: New Images for Object...</a></td>
-                </tr>
-                <tr>
-                    <td>2</td>
-                    <td>&rarrb;</td>
-                    <td><a href="#">2839492</a></td>
-                    <td>1h 30s ago</td>
-                    <td>30m 10s</td>
-                    <td><a href="#">agomez</a></td>
-                    <td><a href="#">141173: [GTK] Web Inspector: New Images for Object...</a></td>
-                </tr>
-                <tr>
-                    <td>2</td>
-                    <td>&larr;</td>
-                    <td><a href="#">2839492</a></td>
-                    <td>1h 30s ago</td>
-                    <td>30m 10s</td>
-                    <td><a href="#">agomez</a></td>
-                    <td><a href="#">141173: [GTK] Web Inspector: New Images for Object...</a></td>
-                </tr>
-                <tr>
-                    <td>2</td>
-                    <td>&rarrb;</td>
-                    <td><a href="#">2839492</a></td>
-                    <td>1h 30s ago</td>
-                    <td>30m 10s</td>
-                    <td><a href="#">agomez</a></td>
-                    <td><a href="#">141173: [GTK] Web Inspector: New Images for Object...</a></td>
-                </tr>
             </tbody>
         </table>
     </div>
 </div>
+<script type="text/template" id="template-tries-row">
+    <tr>
+        <td>
+            <span class="try-num">
+                <%- try_num %>
+            </span>
+        </td>
+        <td>
+        <%
+            switch(result_type) {
+                case 'try':
+                    print('&rarr;');
+                    break;
+                case 'pass':
+                    print('&rarrb;');
+                    break;
+                case 'fail':
+                    print('&larrb;');
+                    break;
+                case 'abort':
+                    print('&larr;');
+                    break;
+            }
+        %>
+        </td>
+        <td>
+            <a href="<%= patch_url %>">
+                <%- patch_name %>
+            </a>
+        </td>
+        <td>
+            <%- start %>
+        </td>
+        <td>
+            <%- duration %>
+        </td>
+        <td>
+            <a href="<%= author_url %>">
+                <%- author_name %>
+            </a>
+        </td>
+        <td>
+            <a href="<%= author_url %>">
+                <%- bug_description %>
+            </a>
+        </td>
+    </tr>
+</script>
 <script type="text/template" id="template-queue-start">
     <div class="queue-item queue-start">
         <h1><%- name %></h1>
@@ -306,10 +349,21 @@
 <script type="text/javascript" src="External/underscore-min.js"></script>
 <script type="text/javascript">
 
+
+    /**
+     * Underscore template functions
+     */
+
     var templates = {
+        triesRow: _.template($('#template-tries-row').html()),
         queueStart: _.template($('#template-queue-start').html()),
         queueAttempt: _.template($('#template-queue-attempt').html())
     };
+
+
+    /**
+     * Queue flow diagram rows
+     */
 
     function QueueRow(args) {
         // attributes
@@ -339,6 +393,7 @@
     };
 
     var macRow = new QueueRow({
+        $parent: $('#queues'),
         name: 'Mac',
         attempts: [
             {
@@ -398,11 +453,11 @@
                     caption: '2-55s (x\u0305 5s)'
                 }
             }
-        ],
-        $parent: $('#queues')
+        ]
     });
 
     var iosRow = new QueueRow({
+        $parent: $('#queues'),
         name: 'iOS',
         attempts: [
             {
@@ -443,9 +498,86 @@
                     caption: '2-55s (x\u0305 5s)'
                 }
             }
-        ],
-        $parent: $('#queues')
+        ]
     });
+
+
+    /**
+     * Tries table rows
+     */
+
+    var triesTable = (function () {
+
+        var $tbody = $('#details')
+            .find('.tries-table')
+            .find('tbody');
+
+        function addRow(row) {
+            $tbody.append(templates.triesRow(row));
+        }
+
+        function addRows(rows) {
+            rows.forEach(addRow);
+        }
+
+        return {
+            addRow: addRow,
+            addRows: addRows
+        }
+
+    })();
+
+    triesTable.addRow({
+        try_num: 1,
+        result_type: 'try',
+        patch_name: 2839492,
+        patch_url: '#',
+        start: '1h 30s ago',
+        duration: '30m 10s',
+        author_name: 'agomez',
+        author_url: '#',
+        bug_description: '141173: [GTK] Web Inspector: New Images for Object...',
+        bug_url: '#'
+    });
+
+    triesTable.addRows([
+        {
+            try_num: 2,
+            result_type: 'abort',
+            patch_name: 2839492,
+            patch_url: '#',
+            start: '1h 30s ago',
+            duration: '30m 10s',
+            author_name: 'agomez',
+            author_url: '#',
+            bug_description: '141173: [GTK] Web Inspector: New Images for Object...',
+            bug_url: '#'
+        },
+        {
+            try_num: 3,
+            result_type: 'pass',
+            patch_name: 2839492,
+            patch_url: '#',
+            start: '1h 30s ago',
+            duration: '30m 10s',
+            author_name: 'agomez',
+            author_url: '#',
+            bug_description: '141173: [GTK] Web Inspector: New Images for Object...',
+            bug_url: '#'
+        },
+        {
+            try_num: 4,
+            result_type: 'fail',
+            patch_name: 2839492,
+            patch_url: '#',
+            start: '1h 30s ago',
+            duration: '30m 10s',
+            author_name: 'agomez',
+            author_url: '#',
+            bug_description: '141173: [GTK] Web Inspector: New Images for Object...',
+            bug_url: '#'
+        }
+    ]);
 
 </script>
 </body>

--- a/dashboard/pipeline2.html
+++ b/dashboard/pipeline2.html
@@ -5,20 +5,40 @@
     <title>WebKit Bot Watcher's Dashboard: Pipeline Metrics</title>
     <style type="text/css">
 
+        /**
+         * General page rules
+         */
+
         body {
             padding: 15px;
             font-family: sans-serif;
+            background-color: #E9E7DF;
+            color: #5C5C5C;
         }
 
         .content {
-            min-width: 930px;
+            width: 930px;
+            margin: auto;
             position: relative;
         }
 
+        .page-title {
+            margin-bottom: 32px;
+            text-align: center;
+        }
+
+        /**
+         * Queue flow diagrams
+         */
+
         .legend {
             position: absolute;
-            top: 15px;
+            top: 31px;
             right: 15px;
+        }
+
+        #queues {
+            position: relative;
         }
 
         .queue-row {
@@ -29,7 +49,7 @@
 
         .queue-item {
             width: auto;
-            height: 270px;
+            height: 275px;
             float: left;
             position: relative;
         }
@@ -44,6 +64,35 @@
             text-align: center;
         }
 
+        /**
+         * Time histograms
+         */
+
+        /**
+         * Tries table
+         */
+
+        .tries-table {
+            width: 100%;
+            max-width: 100%;
+            margin-bottom: 20px;
+            border-spacing: 0;
+            border-collapse: collapse;
+        }
+        .tries-table td,
+        .tries-table th {
+            padding: 5px;
+            text-align: left;
+        }
+        .tries-table thead {
+            padding-bottom: 4px;
+            margin-bottom: 4px;
+            border-bottom: 3px solid #9C9C9C;
+        }
+        .tries-table tbody {
+            padding-top: 10px;
+        }
+
     </style>
 </head>
 <body>
@@ -54,6 +103,9 @@
     - kill multispace   (?<=\S)  +
 -->
 <div class="content">
+    <h1 class="page-title">
+        WebKit Bot Watcher's Dashboard: Pipeline Metrics
+    </h1>
     <div id="queues">
         <div class="legend">
             <svg width="145px" height="212px" viewBox="0 0 145 210" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -64,7 +116,7 @@
                             <path d="M11.6177078,33 L11.6177079,0.0674695235 L0.98959976,0.0674695235 L16.2685848,0.0674695235 L23.0104002,0.0674695235" ></path>
                         </g>
                         <text font-family="Helvetica Neue" font-size="14" font-weight="420" fill="#7D7D7D">
-                            <tspan x="57.608" y="19">PASS</tspan>
+                            <tspan text-anchor="middle" x="76" y="19">PASS</tspan>
                         </text>
                     </g>
                     <g transform="translate(17.000000, 53.000000)">
@@ -72,7 +124,7 @@
                             <path d="M10.6495655,32.9120852 L10.6495656,3.55271368e-15 L0.907133113,4.37819587e-15 L14.9128694,4.37819587e-15 L21.0928669,4.37819587e-15" transform="translate(11.000000, 16.456043) scale(1, -1) translate(-11.000000, -16.456043) "></path>
                         </g>
                         <text font-family="Helvetica Neue" font-size="14" font-weight="420" fill="#7D7D7D">
-                            <tspan x="61.101" y="17">FAIL</tspan>
+                            <tspan text-anchor="middle" x="76" y="17">FAIL</tspan>
                         </text>
                     </g>
                     <g transform="translate(14.000000, 92.000000)">
@@ -81,7 +133,7 @@
                             <path d="M1.39796145,6 L31.5973985,6" stroke-width="4"></path>
                         </g>
                         <text font-family="Helvetica Neue" font-size="14" font-weight="420" fill="#7D7D7D">
-                            <tspan x="64.806" y="14.75">TRY</tspan>
+                            <tspan text-anchor="middle" x="76" y="14.75">TRY</tspan>
                         </text>
                     </g>
                     <g transform="translate(16.000000, 129.000000)">
@@ -90,12 +142,12 @@
                             <path d="M1.39796145,6 L31.5973985,6" stroke-width="4"></path>
                         </g>
                         <text font-family="Helvetica Neue" font-size="14" font-weight="420" fill="#7D7D7D">
-                            <tspan x="53.63" y="14.5">ABORT</tspan>
+                            <tspan text-anchor="middle" x="76" y="14.5">ABORT</tspan>
                         </text>
                     </g>
                     <g transform="translate(25.000000, 160.000000)">
                         <text font-family="Helvetica Neue" font-size="14" font-weight="420" fill="#7D7D7D">
-                            <tspan x="48.306" y="17.5">TRY #</tspan>
+                            <tspan text-anchor="middle" x="68" y="17.5">TRY #</tspan>
                         </text>
                         <g >
                             <circle stroke="#979797" stroke-width="1.60000002" fill="#F6F6F6" cx="13" cy="13" r="13"></circle>
@@ -107,6 +159,60 @@
                 </g>
             </svg>
         </div>
+    </div>
+    <div id="histograms"></div>
+    <div id="details">
+        <table class="tries-table">
+            <thead>
+                <tr>
+                    <th>Try</th>
+                    <th>Result</th>
+                    <th>Patch</th>
+                    <th>Start</th>
+                    <th>Duration</th>
+                    <th>Author</th>
+                    <th>Bug description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>1</td>
+                    <td>&rarr;</td>
+                    <td><a href="#">2839492</a></td>
+                    <td>1h 30s ago</td>
+                    <td>30m 10s</td>
+                    <td><a href="#">agomez</a></td>
+                    <td><a href="#">141173: [GTK] Web Inspector: New Images for Object...</a></td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td>&rarrb;</td>
+                    <td><a href="#">2839492</a></td>
+                    <td>1h 30s ago</td>
+                    <td>30m 10s</td>
+                    <td><a href="#">agomez</a></td>
+                    <td><a href="#">141173: [GTK] Web Inspector: New Images for Object...</a></td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td>&larr;</td>
+                    <td><a href="#">2839492</a></td>
+                    <td>1h 30s ago</td>
+                    <td>30m 10s</td>
+                    <td><a href="#">agomez</a></td>
+                    <td><a href="#">141173: [GTK] Web Inspector: New Images for Object...</a></td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td>&rarrb;</td>
+                    <td><a href="#">2839492</a></td>
+                    <td>1h 30s ago</td>
+                    <td>30m 10s</td>
+                    <td><a href="#">agomez</a></td>
+                    <td><a href="#">141173: [GTK] Web Inspector: New Images for Object...</a></td>
+                </tr>
+            </tbody>
+        </table>
     </div>
 </div>
 <script type="text/template" id="template-queue-start">


### PR DESCRIPTION
Both queue diagram rows and tries table rows are templated out and can be generated from JSON.

Note: dummy data for both is presentational/derived. When we're getting actual data we'll need to crunch it into shape for both queue and tries (calculate percentages, make human-readable start times and durations, etc). 

![screen shot 2015-05-01 at 5 44 45 pm](https://cloud.githubusercontent.com/assets/409114/7439283/37675dda-f02a-11e4-883a-28abe5c8f200.png)
